### PR TITLE
fix: Add ioredis types dep + Apply Node20

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,11 +18,11 @@ jobs:
           - 6379:6379
         options: --entrypoint redis-server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
       - name: Prepare dot npmrc for private registry
         run: echo //npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }} >> ~/.npmrc

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,7 +50,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - uses: 8BitJonny/gh-get-current-pr@2.2.0
@@ -66,14 +66,14 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100 # 최근 100개 커밋에서 package.json 버전변경 확인
           token: ${{ env.PUSH_TOKEN }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
           # Defaults to the user or organization that owns the workflow file
           scope: '@day1co'


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 새로운 기능

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
@types/ioredis 디펜던시가 없어서 fastlock을 사용하는 곳에서 에러가 발생한다.
 
<img width="731" alt="Screenshot 2023-11-27 at 5 13 30 PM" src="https://github.com/day1co/fastlock/assets/63729090/5c3cbb08-1f13-4cd9-a855-4c8bd2fe5432">

노드 20 버전을 적용한다

## 무엇을 어떻게 변경했나요?
워크플로우에 노드 20 적용
devDependencies에 @types/ioredis 추가
